### PR TITLE
added option to track proph vars in the implicit abstraction

### DIFF
--- a/ic3ia/ia.h
+++ b/ic3ia/ia.h
@@ -65,7 +65,8 @@ public:
     ~PredRefMinimizer();
     
     bool operator()(msat_term trans, const std::vector<TermList> &cex,
-                    msat_term predabs, TermSet &newpreds);
+                    msat_term predabs, TermSet &newpreds,
+                    const TermSet *imp_vars = NULL);
 
 private:
     const TransitionSystem &ts_;
@@ -81,6 +82,8 @@ private:
     
     msat_env minsolver_;
     ///< the solver for predicate minimization
+
+    bool track_proph_vars_pred;
 };
 
 
@@ -92,7 +95,7 @@ public:
     Refiner(const TransitionSystem &ts, const Options &opts, Abstractor &abs);
     ~Refiner();
 
-    bool refine(const std::vector<TermList> &cex);
+    bool refine(const std::vector<TermList> &cex, const TermSet *imp_vars=NULL);
     ///< try to refine the given counterexample trace. If successful, computes
     ///< a sequence interpolant for the trace. Otherwise, a concrete
     ///< counterexample trace is generated
@@ -111,7 +114,7 @@ public:
 
 private:
     void extract_predicates(msat_env env);
-    void minimize_predicates(const std::vector<TermList> &cex);
+    void minimize_predicates(const std::vector<TermList> &cex, const TermSet *imp_vars=NULL);
     
     const TransitionSystem &ts_;
     ///< the input transition system

--- a/ic3ia/ic3.cpp
+++ b/ic3ia/ic3.cpp
@@ -170,6 +170,12 @@ void IC3::print_stats() const
 }
 
 
+void IC3::add_imp_pred_var(msat_term v)
+{
+    imp_pred_vars_.insert(v);
+}
+
+
 //-----------------------------------------------------------------------------
 // major methods
 //-----------------------------------------------------------------------------
@@ -593,7 +599,7 @@ msat_truth_value IC3::refine_abstraction(std::vector<TermList> &cex)
         }
     }
 
-    if (ref_.refine(cex)) {
+    if (ref_.refine(cex, &imp_pred_vars_)) {
         // if refinement is successful, we extract new predicates from the
         // sequence interpolant
         int c = 0;

--- a/ic3ia/ic3.h
+++ b/ic3ia/ic3.h
@@ -63,7 +63,11 @@ public:
 
     void print_stats() const;
     ///< print search statistics on stdout
-    
+
+    void add_imp_pred_var(msat_term v);
+    ////< adds a variable that is important to track with implicit predicate
+    ////< abstraction
+
 private:
     //------------------------------------------------------------------------
     // internal data structures
@@ -78,6 +82,7 @@ private:
     typedef std::vector<Frame> FrameList;
     ///< the trace F is a vector of frames
 
+  
     /**
      * A proof obligation is a pair <C,k> where C is a bad cube to block and k
      * is a position in the current trace. The pair represents the relative
@@ -358,6 +363,9 @@ private:
     LiveRefiner liveref_; ///< refiner for liveness properties
     RankRelList rankrels_; ///< list of ranking relations used in the encoding
     TermSet livepreds_; ///< set of predicates for the abstract L2S
+
+    TermSet imp_pred_vars_; ///< set of variables that are important to track in
+                            ///the implicit abstraction
 
     //------------------------------------------------------------------------
     // statistics

--- a/ic3ia/opts.h
+++ b/ic3ia/opts.h
@@ -60,6 +60,7 @@ struct Options {
     int max_array_axioms;
     bool use_single_uf;
     bool unsatcore_array_refiner;
+    bool track_proph_vars_pred;
 
     Options()
     {
@@ -94,7 +95,8 @@ struct Options {
         use_hist_eq_initial_preds = true;
         max_array_axioms = 0;
         use_single_uf = false;
-	unsatcore_array_refiner = false;
+        unsatcore_array_refiner = false;
+        track_proph_vars_pred = false;
     }
 };
 

--- a/prophic3/prophic3.cpp
+++ b/prophic3/prophic3.cpp
@@ -142,6 +142,14 @@ msat_truth_value ProphIC3::prove()
     std::cout << "Running IC3" << std::endl;
     IC3 ic3(abs_ts_, opts_, l2s_);
     ic3.set_initial_predicates(preds_);
+    // tell ic3 about imporant variables (prophecy variables)
+    for (auto v : prop_free_vars) {
+      ic3.add_imp_pred_var(v);
+    }
+    for (auto v : frozen_proph_vars_) {
+      ic3.add_imp_pred_var(v.first);
+    }
+
     res = ic3.prove();
 
     if (res == MSAT_FALSE)

--- a/prophic3/utils.cpp
+++ b/prophic3/utils.cpp
@@ -240,6 +240,8 @@ Options get_options(int argc, const char **argv)
           ret.use_single_uf = true;
         } else if (a == "-unsatcore-array-refiner") {
           ret.unsatcore_array_refiner = true;
+        } else if (a == "-track-proph-vars-pred") {
+          ret.track_proph_vars_pred = true;
         } else if (a == "-h" || a == "-help" || a == "--help") {
             std::cout << "USAGE: " << argv[0] << " [OPTIONS] FILENAME.vmt"
                       << "\n\n   -v N : set verbosity level"
@@ -278,6 +280,8 @@ Options get_options(int argc, const char **argv)
                       << "\n   -use-single-uf : use a single UF per array type (without this option "
                       << "it's per array variable)"
                       << "\n   -unsatcore-array-refiner : use unsatcore in the array refiner to filter axioms "
+                      << "\n -track-proph-vars-pred : don't throw away predicates while minimizing if they "
+                      << "contain prophecy variables"
                       << std::endl;
             exit(0);
             break;


### PR DESCRIPTION
this PR adds an option to track the proph-variables in the implicit abstraction. We will not throw predicates that contain prophecy variables in the predicate-minimization phase.

The option is off by default.

An example to try:
`./prophic3 -use-single-uf ../../exps/chc-comp-2019/vmt/chc-lia-lin-arr-0058.smt2.vmt -v 2 -track-proph-vars-pred`